### PR TITLE
Feat#17 회원가입 페이지 생성

### DIFF
--- a/iTER/src/App.tsx
+++ b/iTER/src/App.tsx
@@ -1,44 +1,16 @@
-import ButtonWithInput from './component/common/Input';
-import Error from './assets/icon/Error.svg?react';
 import Login from './pages/Login';
+import { Route, Routes } from 'react-router-dom';
+import Home from './pages/Home';
+import SignUp from './pages/signup/SignUp';
 
 function App() {
-
-  //이건 그냥 버튼 활성화되는지 안되는지 확인하려고 쓴 함수
-  const handleButtonClick = () => {
-    console.log('버튼이 클릭되었습니다.');
-  };
-
-  //이메일 유효성 검사
-  const validateEmail = (value: string) => {
-    const isEmailValid = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(
-      value.trim()
-    );
-    return isEmailValid ? undefined : "유효한 이메일이 아닙니다";
-  };
-
-
-
-
   return (
-    // <Routes>
-    //   <Route path="/" element={<Home />} />
-    //   <Route path="/test" element={<Test />} />
-      
-    // </Routes>
-    
-
-    <ButtonWithInput
-        labelName="이메일"
-        btnName="확인"
-        type="text"
-        placeholder="이메일을 입력하세요"
-        onClick={handleButtonClick}
-        onValidate={validateEmail} 
-      />
-    // <Login />
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/login" element={<Login />} />
+      <Route path="/signup" element={<SignUp />} />
+    </Routes>
   );
 }
-
 
 export default App;

--- a/iTER/src/assets/icon/CheckCircle.svg
+++ b/iTER/src/assets/icon/CheckCircle.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="8" cy="8" r="8" fill='current'/>
+<path d="M6.36689 12L2.56689 8.2L3.51689 7.25L6.36689 10.1L12.4836 3.98334L13.4336 4.93334L6.36689 12Z" fill="white"/>
+</svg>

--- a/iTER/src/component/common/Button.tsx
+++ b/iTER/src/component/common/Button.tsx
@@ -9,23 +9,6 @@ interface ButtonProps {
 }
 const ButtonBody = styled('button', {
   width: '340px',
-  height: '55px',
-  borderRadius: '27.5px',
-  backgroundColor: '$Brand',
-  border: 'none',
-  color: '$White',
-  variants: {
-    disabled: {
-      true: {
-        backgroundColor: '$Gray20', // 비활성화에는 그레이20으로
-        cursor: 'not-allowed', // 비활성화에는 커서 못둠
-      },
-      false: {},
-    },
-  },
-});
-const SquareBody = styled('button', {
-  width: '340px',
   height: '45px',
   borderRadius: '10px',
   backgroundColor: '$Brand',
@@ -34,8 +17,8 @@ const SquareBody = styled('button', {
   variants: {
     disabled: {
       true: {
-        backgroundColor: '$Gray20', // 비활성화에는 그레이20으로
-        cursor: 'not-allowed', // 비활성화에는 커서 못둠
+        backgroundColor: '$Gray20',
+        cursor: 'not-allowed',
       },
       false: {},
     },
@@ -64,19 +47,4 @@ const Button: FC<ButtonProps> = ({ onClick, children, disabled }) => {
   );
 };
 
-export const ButtonSquare: FC<ButtonProps> = ({ onClick, children, disabled }) => {
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
-    if (!disabled && onClick) {
-      onClick(event);
-    }
-  };
-
-  return (
-    <>
-      <SquareBody onClick={handleClick} disabled={disabled}>
-        <ButtonText>{children}</ButtonText>
-      </SquareBody>
-    </>
-  );
-};
 export default Button;

--- a/iTER/src/component/common/Button.tsx
+++ b/iTER/src/component/common/Button.tsx
@@ -7,33 +7,48 @@ interface ButtonProps {
   children: ReactNode;
   disabled?: boolean;
 }
-const ButtonBody = styled("button", {
-    width: "340px",
-    height: "55px",
-    borderRadius: "27.5px",
-    backgroundColor: "$Brand",
-    border: "none",
-    color: "$White",
-    variants: {
-        disabled: {
-          true: {
-            backgroundColor: "$Gray20", // 비활성화에는 그레이20으로
-            cursor: "not-allowed", // 비활성화에는 커서 못둠
-          },
-          false: {},
-        },
+const ButtonBody = styled('button', {
+  width: '340px',
+  height: '55px',
+  borderRadius: '27.5px',
+  backgroundColor: '$Brand',
+  border: 'none',
+  color: '$White',
+  variants: {
+    disabled: {
+      true: {
+        backgroundColor: '$Gray20', // 비활성화에는 그레이20으로
+        cursor: 'not-allowed', // 비활성화에는 커서 못둠
       },
-    
-  });
-
+      false: {},
+    },
+  },
+});
+const SquareBody = styled('button', {
+  width: '340px',
+  height: '45px',
+  borderRadius: '10px',
+  backgroundColor: '$Brand',
+  border: 'none',
+  color: '$White',
+  variants: {
+    disabled: {
+      true: {
+        backgroundColor: '$Gray20', // 비활성화에는 그레이20으로
+        cursor: 'not-allowed', // 비활성화에는 커서 못둠
+      },
+      false: {},
+    },
+  },
+});
 
 interface ButtonProps {
-    onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
-    children: ReactNode;
-    disabled?: boolean;
-  }
+  onClick?: (event: MouseEvent<HTMLButtonElement>) => void;
+  children: ReactNode;
+  disabled?: boolean;
+}
 
-const Button: FC<ButtonProps> = ({ onClick, children, disabled, }) => {
+const Button: FC<ButtonProps> = ({ onClick, children, disabled }) => {
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     if (!disabled && onClick) {
       onClick(event);
@@ -42,12 +57,26 @@ const Button: FC<ButtonProps> = ({ onClick, children, disabled, }) => {
 
   return (
     <>
-    <ButtonBody onClick={handleClick} disabled={disabled}>
-      <ButtonText>{children}</ButtonText>
-    </ButtonBody>
+      <ButtonBody onClick={handleClick} disabled={disabled}>
+        <ButtonText>{children}</ButtonText>
+      </ButtonBody>
     </>
   );
 };
 
+export const ButtonSquare: FC<ButtonProps> = ({ onClick, children, disabled }) => {
+  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+    if (!disabled && onClick) {
+      onClick(event);
+    }
+  };
 
+  return (
+    <>
+      <SquareBody onClick={handleClick} disabled={disabled}>
+        <ButtonText>{children}</ButtonText>
+      </SquareBody>
+    </>
+  );
+};
 export default Button;

--- a/iTER/src/component/common/Input.tsx
+++ b/iTER/src/component/common/Input.tsx
@@ -7,8 +7,11 @@ interface ButtonWithInputProps {
   btnName?: string;
   placeholder: string;
   onClick?: () => void;
-  onValidate: (value: string) => string | undefined;
   type: 'text' | 'password'; // type prop 추가
+  onChange?: (value: string) => void;
+  error?: string;
+  disabled?: boolean;
+  notice?: string;
 }
 
 const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
@@ -17,25 +20,22 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
   placeholder,
   type,
   onClick,
-  onValidate,
+  onChange,
+  error,
+  disabled,
+  notice,
 }) => {
-  const [inputValue, setInputValue] = useState<string>('');
-  const [error, setError] = useState<string | undefined>('');
-
   const handleInputValueChange = (value: string) => {
-    setInputValue(value);
-    const validationError = onValidate(value);
-    setError(validationError);
+    onChange && onChange(value);
   };
-
-  const isInputValid = !error;
 
   return (
     <div>
       <Label>{labelName}</Label>
+      {notice && <Notice>{notice}</Notice>}
       <Body
         style={{
-          border: isInputValid ? '1px solid #D8DBE2' : '1px solid #F34F45',
+          border: !error ? '1px solid #D8DBE2' : '1px solid #F34F45',
         }}
       >
         <InBody>
@@ -47,10 +47,10 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
           {btnName && ( // btnName이 빈 문자열이 아닐 때만 버튼을 렌더링
             <Button
               style={{
-                backgroundColor: isInputValid ? '#4C4E55' : '#c1c4cc',
-                pointerEvents: isInputValid ? 'auto' : 'none',
+                backgroundColor: !disabled ? '#4C4E55' : '#c1c4cc',
+                pointerEvents: !disabled ? 'auto' : 'none',
               }}
-              onClick={isInputValid ? onClick : undefined}
+              onClick={!disabled ? onClick : undefined}
             >
               {btnName}
             </Button>
@@ -63,7 +63,6 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
             display: 'flex',
             alignItems: 'center',
             color: '#F34F45',
-            height: '100%',
           }}
         >
           <Error />
@@ -153,11 +152,18 @@ const Label = styled('div', {
 });
 
 const ErrorMessage = styled('div', {
-  color: 'red',
+  color: '$ErrorRed',
   fontSize: '13px',
   lineHeight: '18.2px',
   fontWeight: '400',
   marginTop: '10px',
+});
+
+const Notice = styled('div', {
+  color: '$Gray20',
+  fontSize: '12px',
+  marginTop: '-6px',
+  marginBottom: '10px',
 });
 
 export default ButtonWithInput;

--- a/iTER/src/component/common/Input.tsx
+++ b/iTER/src/component/common/Input.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { styled } from '../../../stitches.config';
-import Error from "../../assets/icon/Error.svg?react";
+import Error from '../../assets/icon/Error.svg?react';
 
 interface ButtonWithInputProps {
   labelName: string;
-  btnName: string;
+  btnName?: string;
   placeholder: string;
-  onClick: () => void;
+  onClick?: () => void;
   onValidate: (value: string) => string | undefined;
   type: 'text' | 'password'; // type prop 추가
 }
@@ -18,7 +18,6 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
   type,
   onClick,
   onValidate,
-  
 }) => {
   const [inputValue, setInputValue] = useState<string>('');
   const [error, setError] = useState<string | undefined>('');
@@ -34,9 +33,11 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
   return (
     <div>
       <Label>{labelName}</Label>
-      <Body style={{ 
-        border: isInputValid ? '1px solid #D8DBE2' : '1px solid #F34F45',
-        }}>
+      <Body
+        style={{
+          border: isInputValid ? '1px solid #D8DBE2' : '1px solid #F34F45',
+        }}
+      >
         <InBody>
           <InputComponent
             placeholder={placeholder}
@@ -57,15 +58,19 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
         </InBody>
       </Body>
       {error && (
-      <div style={{ 
-        display: 'flex',
-        alignItems: 'center',
-        color: "#F34F45",
-        height: "100%",
-          }}>
-      <Error />
-      <span style={{marginLeft: "10px", marginBottom: "10px"}}><ErrorMessage>{error}</ErrorMessage></span>
-      </div>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            color: '#F34F45',
+            height: '100%',
+          }}
+        >
+          <Error />
+          <span style={{ marginLeft: '10px', marginBottom: '10px' }}>
+            <ErrorMessage>{error}</ErrorMessage>
+          </span>
+        </div>
       )}
     </div>
   );
@@ -73,9 +78,8 @@ const ButtonWithInput: React.FC<ButtonWithInputProps> = ({
 
 const InputComponent: React.FC<{
   placeholder: string;
-  type: 'text' | 'password'; 
+  type: 'text' | 'password';
   onChange: (value: string) => void;
-  
 }> = ({ placeholder, onChange, type }) => {
   const [inputValue, setInputValue] = useState<string>('');
 
@@ -88,13 +92,13 @@ const InputComponent: React.FC<{
   return (
     <>
       <input
-        type={type} 
+        type={type}
         placeholder={placeholder}
         value={inputValue}
         onChange={handleInputChange}
         style={{
           border: 'none',
-          height: '22px',
+          height: '50px',
           marginLeft: '10px',
           backgroundColor: 'White',
           outline: 'none',
@@ -109,7 +113,7 @@ const InputComponent: React.FC<{
 };
 
 const Body = styled('div', {
-  padding: "2px 5px",
+  padding: '2px 5px',
   borderRadius: '7px',
   width: '340px',
   height: '50px',

--- a/iTER/src/index.css
+++ b/iTER/src/index.css
@@ -14,6 +14,11 @@
   -webkit-text-size-adjust: 100%;
 }
 
+body {
+  width: 390px;
+  margin: 0 auto;
+}
+
 button {
   cursor: pointer;
 }
@@ -31,4 +36,3 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
-

--- a/iTER/src/pages/signup/SignUp.tsx
+++ b/iTER/src/pages/signup/SignUp.tsx
@@ -1,0 +1,115 @@
+import { styled } from '../../../stitches.config';
+import { ButtonSquare } from '../../component/common/Button';
+import ButtonWithInput from '../../component/common/Input';
+import { Headline3 } from '../../component/Font';
+import Top from '../../component/layout/Top';
+import CheckCircle from '../../assets/icon/CheckCircle.svg?react';
+import { useState } from 'react';
+
+const SignUp = () => {
+  const [check, setCheck] = useState<boolean>(false);
+
+  //이메일 유효성 검사
+  const validateEmail = (value: string) => {
+    const isEmailValid = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value.trim());
+    return isEmailValid ? undefined : '유효한 이메일이 아닙니다';
+  };
+  //인증번호 확인
+  const validateAuthNumber = (value: string) => {
+    const isAuthNumberValid = /^[0-9]{6}$/i.test(value.trim());
+    return isAuthNumberValid ? undefined : '인증번호가 일치하지 않습니다';
+  };
+  //비밀번호 유효성 검사
+  const validatePassword = (value: string) => {
+    const isPasswordValid = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,16}$/i.test(
+      value.trim()
+    );
+    return isPasswordValid
+      ? undefined
+      : '비밀번호는 8~16자리의 영문 대소문자, 숫자, 특수문자를 사용하세요';
+  };
+
+  return (
+    <>
+      <Top title="회원가입" />
+      <Content>
+        <Title>
+          <Headline3>ITer에 오신걸 환영합니다</Headline3>
+        </Title>
+        <ButtonWithInput
+          placeholder="이메일을 입력해주세요"
+          onValidate={validateEmail}
+          type="text"
+          labelName="이메일"
+          btnName="인증번호 전송"
+          onClick={function (): void {
+            throw new Error('Function not implemented.');
+          }}
+        />
+        <div style={{ marginTop: 20 }} />
+        <ButtonWithInput
+          placeholder="인증번호를 6자리를 입력해주세요"
+          onValidate={validateAuthNumber}
+          type="text"
+          labelName="인증번호"
+          btnName="인증번호 확인"
+          onClick={function (): void {
+            throw new Error('Function not implemented.');
+          }}
+        />
+        <div style={{ marginTop: 20 }} />
+        <ButtonWithInput
+          placeholder="비밀번호를 입력해주세요"
+          onValidate={validatePassword}
+          type="password"
+          labelName="비밀번호"
+        />
+        <Bottom>
+          <Terms onClick={() => setCheck(!check)} check={check}>
+            <CheckCircle fill={check ? '#8787F4' : '#C1C4CC'} />
+            ITer 서비스이용약관에 동의합니다.
+          </Terms>
+          <ButtonSquare disabled>다음</ButtonSquare>
+        </Bottom>
+      </Content>
+    </>
+  );
+};
+export default SignUp;
+const Content = styled('div', {
+  width: '100%',
+  height: '100vh',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+});
+
+const Title = styled('div', {
+  margin: '114px 0 45px 40px',
+  width: '100%',
+  textAlign: 'left',
+});
+const Terms = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  fontSize: '12px',
+  fontWeight: '400',
+  marginBottom: '12px',
+  gap: '4px',
+  variants: {
+    check: {
+      true: {
+        color: '$Gray50',
+      },
+      false: {
+        color: '$Gray20',
+      },
+    },
+  },
+});
+
+const Bottom = styled('div', {
+  borderBottom: 'solid 1px #EAEEF2',
+  position: 'absolute',
+  bottom: '10px',
+});

--- a/iTER/src/pages/signup/SignUp.tsx
+++ b/iTER/src/pages/signup/SignUp.tsx
@@ -1,5 +1,5 @@
 import { styled } from '../../../stitches.config';
-import { ButtonSquare } from '../../component/common/Button';
+import Button from '../../component/common/Button';
 import ButtonWithInput from '../../component/common/Input';
 import { Headline3 } from '../../component/Font';
 import Top from '../../component/layout/Top';
@@ -84,7 +84,7 @@ const SignUp = () => {
             <CheckCircle fill={check ? '#8787F4' : '#C1C4CC'} />
             ITer 서비스이용약관에 동의합니다.
           </Terms>
-          <ButtonSquare disabled>다음</ButtonSquare>
+          <Button disabled>다음</Button>
         </Bottom>
       </Content>
     </>

--- a/iTER/src/pages/signup/SignUp.tsx
+++ b/iTER/src/pages/signup/SignUp.tsx
@@ -8,25 +8,32 @@ import { useState } from 'react';
 
 const SignUp = () => {
   const [check, setCheck] = useState<boolean>(false);
+  const [email, setEmail] = useState<string>('');
+  const [authNum, setAuthNum] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
 
+  const [emailWarning, setEmailWarning] = useState<string>('');
+  const [authWarning, setAuthWarning] = useState<string>('');
   //이메일 유효성 검사
   const validateEmail = (value: string) => {
     const isEmailValid = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(value.trim());
-    return isEmailValid ? undefined : '유효한 이메일이 아닙니다';
-  };
-  //인증번호 확인
-  const validateAuthNumber = (value: string) => {
-    const isAuthNumberValid = /^[0-9]{6}$/i.test(value.trim());
-    return isAuthNumberValid ? undefined : '인증번호가 일치하지 않습니다';
+    return isEmailValid;
   };
   //비밀번호 유효성 검사
   const validatePassword = (value: string) => {
     const isPasswordValid = /^(?=.*[a-zA-Z])(?=.*[!@#$%^*+=-])(?=.*[0-9]).{8,16}$/i.test(
       value.trim()
     );
-    return isPasswordValid
-      ? undefined
-      : '비밀번호는 8~16자리의 영문 대소문자, 숫자, 특수문자를 사용하세요';
+    return isPasswordValid;
+  };
+
+  const handleEmailButton = () => {
+    console.log('Email click?');
+    validateEmail(email) ? setEmailWarning('') : setEmailWarning('이메일 형식이 올바르지 않습니다');
+  };
+  const handleAuthButton = () => {
+    console.log(authNum, 'Auth click');
+    authNum === '123456' ? setAuthWarning('') : setAuthWarning('인증번호가 올바르지 않습니다');
   };
 
   return (
@@ -36,34 +43,42 @@ const SignUp = () => {
         <Title>
           <Headline3>ITer에 오신걸 환영합니다</Headline3>
         </Title>
+
         <ButtonWithInput
           placeholder="이메일을 입력해주세요"
-          onValidate={validateEmail}
           type="text"
           labelName="이메일"
           btnName="인증번호 전송"
-          onClick={function (): void {
-            throw new Error('Function not implemented.');
-          }}
+          onClick={() => handleEmailButton()}
+          onChange={setEmail}
+          disabled={email.length == 0}
+          error={emailWarning}
         />
         <div style={{ marginTop: 20 }} />
         <ButtonWithInput
           placeholder="인증번호를 6자리를 입력해주세요"
-          onValidate={validateAuthNumber}
           type="text"
           labelName="인증번호"
-          btnName="인증번호 확인"
-          onClick={function (): void {
-            throw new Error('Function not implemented.');
-          }}
+          btnName="확인"
+          onClick={() => handleAuthButton()}
+          onChange={setAuthNum}
+          disabled={authNum.length != 6}
+          error={authWarning}
         />
         <div style={{ marginTop: 20 }} />
         <ButtonWithInput
           placeholder="비밀번호를 입력해주세요"
-          onValidate={validatePassword}
           type="password"
           labelName="비밀번호"
+          onChange={setPassword}
+          error={
+            validatePassword(password) || password.length == 0
+              ? undefined
+              : '비밀번호 형식에 맞게 입력해주세요'
+          }
+          notice="영문/숫자/특수문자 3가지 이상 조합 8~20자"
         />
+
         <Bottom>
           <Terms onClick={() => setCheck(!check)} check={check}>
             <CheckCircle fill={check ? '#8787F4' : '#C1C4CC'} />


### PR DESCRIPTION
##  개요
- feat#17
- /signup
- 회원가입 페이지 화면입니다.
<br/>

## 작업 내용
- index.css 수정
- 화면 구현
- 유효성 검사 및 값 저장
<br/>

## To Reviewers
전체 컨테이너가 390px이니까 index.css에 그냥 추가했습니다!
각진 버튼이 필요해서 ButtonComponent에 ButtonSquare 추가했습니다.
다음으로 넘어가는 버튼 활성화 여부는 API 연결 후에 설정하겠습니다.

Input 컴포넌트 일부 수정했습니다.
- 원래 값을 입력할때마다 유효성 체크를 했었는데 인증번호는 버튼을 눌러 체크해야할 것 같아서 수정했습니다.

- 유효성 체크 함수를 없애고 error 메시지만 받도록했어요!
- 버튼 비활성화 추가했습니다.
- 비밀번호 체크시 나오는 메시지를 위해 notice 추가했습니다.

<br/>

## 구현 화면
<img width="577" alt="스크린샷 2023-10-02 오후 1 46 24" src="https://github.com/BETTER-iTER/Web/assets/78204289/29b9a055-b066-4848-adf4-f9b1a58254c7">
