### PR TITLE
Feat#25 회원가입 추가정보

### DIFF
--- a/iTER/src/App.tsx
+++ b/iTER/src/App.tsx
@@ -2,6 +2,8 @@ import Login from './pages/Login';
 import { Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
 import SignUp from './pages/signup/SignUp';
+import SignupComplete from './pages/signup/SignupComplete';
+import SignupAdditional from './pages/signup/SignupAdditional';
 
 function App() {
   return (
@@ -9,6 +11,8 @@ function App() {
       <Route path="/" element={<Home />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/signup/additional" element={<SignupAdditional />} />
+      <Route path="/signup/complete" element={<SignupComplete />} />
     </Routes>
   );
 }

--- a/iTER/src/component/Font.ts
+++ b/iTER/src/component/Font.ts
@@ -41,6 +41,7 @@ export const ButtonText = styled('div', {
   fontSize: '15px',
   fontWeight: '600',
   letterSpacing: '-0.3px',
+  fontFamily: 'Pretendard',
 });
 
 export const LabelText = styled('div', {

--- a/iTER/src/component/Font.ts
+++ b/iTER/src/component/Font.ts
@@ -16,6 +16,7 @@ export const Headline3 = styled('div', {
   fontSize: '20px',
   fontWeight: '600',
   letterSpacing: '-0.4px',
+  whiteSpace: 'pre-line',
 });
 
 export const Headline4 = styled('div', {

--- a/iTER/src/component/common/Input.tsx
+++ b/iTER/src/component/common/Input.tsx
@@ -110,9 +110,9 @@ const InputComponent: React.FC<{
 };
 
 const Body = styled('div', {
-  padding: '2px 5px',
+  padding: '0 5px',
   borderRadius: '7px',
-  width: '330px',
+  width: '328px',
   height: '48px',
   alignItems: 'center',
   display: 'flex',
@@ -123,10 +123,12 @@ const Body = styled('div', {
 const Input = styled('input', {
   border: 'none',
   height: '48px',
-  marginLeft: '10px',
+  marginLeft: '7px',
   outline: 'none',
   bodyText: 2,
   width: '200px',
+  backgroundColor: 'transparent',
+  color: '$Gray50',
 });
 
 const Button = styled('button', {
@@ -134,17 +136,15 @@ const Button = styled('button', {
   bodyText: 2,
   height: '30px',
   borderRadius: '5px',
-  margin: '10px 0',
   border: 'none',
-  padding: '5px 10px',
+  marginTop: '10px',
+  marginRight: '3px',
 });
 
 const InBody = styled('div', {
   width: '100%',
   display: 'flex',
-  alignItems: 'center',
   justifyContent: 'space-between',
-  paddingRight: '10px',
 });
 
 const Label = styled('div', {

--- a/iTER/src/component/common/Input.tsx
+++ b/iTER/src/component/common/Input.tsx
@@ -112,8 +112,8 @@ const InputComponent: React.FC<{
 const Body = styled('div', {
   padding: '2px 5px',
   borderRadius: '7px',
-  width: '340px',
-  height: '50px',
+  width: '330px',
+  height: '48px',
   alignItems: 'center',
   display: 'flex',
   flexDirection: 'column',
@@ -122,7 +122,7 @@ const Body = styled('div', {
 
 const Input = styled('input', {
   border: 'none',
-  height: '50px',
+  height: '48px',
   marginLeft: '10px',
   outline: 'none',
   bodyText: 2,

--- a/iTER/src/component/common/InputSelect.tsx
+++ b/iTER/src/component/common/InputSelect.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import { styled } from '../../../stitches.config';
+import { LabelText } from '../Font';
+
+interface InputSelectProps {
+  labelName: string;
+  placeholder: string;
+  onChange?: (value: string) => void;
+  list: string[];
+}
+
+const InputSelect: React.FC<InputSelectProps> = ({ labelName, placeholder, onChange, list }) => {
+  const [click, setClick] = useState(false);
+  const [value, setValue] = useState('');
+
+  return (
+    <>
+      <Label>
+        <LabelText>{labelName}</LabelText>
+      </Label>
+      <Body
+        onClick={() => {
+          setClick(!click);
+        }}
+      >
+        {value || placeholder}
+      </Body>
+      {click && list && (
+        <List>
+          {list.map((item, index) => (
+            <ListItem
+              key={index}
+              onClick={() => {
+                setValue(item);
+                onChange && onChange(item);
+              }}
+              last={index === list.length - 1}
+              first={index === 0}
+            >
+              {item}
+            </ListItem>
+          ))}
+        </List>
+      )}
+    </>
+  );
+};
+
+const Body = styled('div', {
+  padding: '2px 0 2px 12px',
+  borderRadius: '7px',
+  border: '1px solid $Gray10',
+  width: '326px',
+  height: '44px',
+
+  alignItems: 'center',
+  display: 'flex',
+  textAlign: 'left',
+  cursor: 'pointer',
+
+  color: '$Gray30',
+  bodyText: 2,
+});
+
+const Label = styled('div', {
+  color: 'black',
+  marginBottom: '10px',
+});
+
+const List = styled('div', {
+  width: '338px',
+  border: '1px solid $Gray10',
+  borderRadius: '7px',
+
+  bodyText: 2,
+  color: '#8C959F',
+});
+
+const ListItem = styled('div', {
+  height: '44px',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  cursor: 'pointer',
+  '&:hover': {
+    backgroundColor: '$Gray10',
+  },
+  variants: {
+    first: {
+      true: {
+        borderRadius: '6px 6px 0 0',
+      },
+    },
+    last: {
+      true: {
+        borderBottom: 'none',
+        borderRadius: '0 0 6px 6px',
+      },
+      false: {
+        borderBottom: '1px solid $Gray10',
+      },
+    },
+  },
+});
+
+export default InputSelect;

--- a/iTER/src/component/layout/Top.tsx
+++ b/iTER/src/component/layout/Top.tsx
@@ -3,16 +3,12 @@ import Back from '../../assets/icon/Back.svg?react';
 import { useNavigate } from 'react-router-dom';
 import { LabelText } from '../Font';
 
-const Top = ({ title }: { title: string }) => {
+const Top = ({ title, back }: { title: string; back?: () => void }) => {
   const navigate = useNavigate();
 
   return (
     <Container>
-      <BackBox
-        onClick={() => {
-          navigate(-1);
-        }}
-      >
+      <BackBox onClick={back ? back : () => navigate(-1)}>
         <Back />
       </BackBox>
       <Title>

--- a/iTER/src/component/signup/Category.tsx
+++ b/iTER/src/component/signup/Category.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { styled } from '../../../stitches.config';
+import CategoryList, { CategoryProps } from '../../constants/Category';
+const Category = () => {
+  const [selected, setSelected] = useState<number[]>([]);
+  const handleSelect = (id: number) => {
+    const selectedCount = selected.length;
+
+    if (selected.includes(id)) {
+      setSelected(selected.filter((item) => item !== id));
+    } else if (selectedCount < 3) {
+      setSelected([...selected, id]);
+    }
+  };
+
+  return (
+    <Container>
+      {CategoryList.map((item) => {
+        return (
+          <Item
+            key={item.id}
+            id={item.id}
+            name={item.name}
+            onClick={() => handleSelect(item.id)}
+            isSelected={selected.includes(item.id)}
+          />
+        );
+      })}
+    </Container>
+  );
+};
+
+interface CategoryItem extends CategoryProps {
+  onClick: () => void;
+  isSelected: boolean;
+}
+
+const Item = ({ name, onClick, isSelected }: CategoryItem) => {
+  return (
+    <ItemBox onClick={onClick}>
+      <Image isSelected={isSelected}></Image>
+      <Name>{name}</Name>
+    </ItemBox>
+  );
+};
+
+const Container = styled('div', {
+  display: 'grid',
+  gridTemplateColumns: 'repeat(4, 1fr)',
+  backgroundColor: '$White',
+});
+
+const ItemBox = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  cursor: 'pointer',
+  width: 'fit-content',
+  marginBottom: '16px',
+  gap: '4px',
+});
+
+const Image = styled('div', {
+  width: '68px',
+  height: '68px',
+  borderRadius: '50%',
+  variants: {
+    isSelected: {
+      true: {
+        boxShadow: '2px 4px 4px 2px rgba(135, 135, 244, 0.5)',
+      },
+      false: {
+        boxShadow: '2px 4px 4px 2px rgba(158, 158, 158, 0.25)',
+      },
+    },
+  },
+});
+
+const Name = styled('div', {
+  color: '$TitleBlack',
+  bodyText: 2,
+  height: '20px',
+});
+
+export default Category;

--- a/iTER/src/component/signup/Category.tsx
+++ b/iTER/src/component/signup/Category.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { styled } from '../../../stitches.config';
 import CategoryList, { CategoryProps } from '../../constants/Category';
-const Category = () => {
+const Category = ({ onDisabled }: { onDisabled: (value: boolean) => void }) => {
   const [selected, setSelected] = useState<number[]>([]);
   const handleSelect = (id: number) => {
     const selectedCount = selected.length;
@@ -12,6 +12,8 @@ const Category = () => {
       setSelected([...selected, id]);
     }
   };
+
+  onDisabled(selected.length === 0);
 
   return (
     <Container>

--- a/iTER/src/component/signup/Job.tsx
+++ b/iTER/src/component/signup/Job.tsx
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+import InputSelect from '../common/InputSelect';
+
+const Job = () => {
+  const [value, setValue] = useState('');
+  const jobs = ['개발자', '학생', '선생님', '디자이너', '프로듀서', '에디터'];
+
+  console.log(value);
+  return (
+    <>
+      <InputSelect
+        labelName="직업"
+        placeholder="직업을 입력해주세요"
+        list={jobs}
+        onChange={setValue}
+      />
+    </>
+  );
+};
+
+export default Job;

--- a/iTER/src/component/signup/Job.tsx
+++ b/iTER/src/component/signup/Job.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import InputSelect from '../common/InputSelect';
 
-const Job = () => {
+const Job = ({ onDisabled }: { onDisabled: (value: boolean) => void }) => {
   const [value, setValue] = useState('');
   const jobs = ['개발자', '학생', '선생님', '디자이너', '프로듀서', '에디터'];
 
+  onDisabled(value === '');
   console.log(value);
   return (
     <>

--- a/iTER/src/component/signup/Nickname.tsx
+++ b/iTER/src/component/signup/Nickname.tsx
@@ -1,0 +1,45 @@
+import { styled } from '@stitches/react';
+import { useState } from 'react';
+import ButtonWithInput from '../common/Input';
+import { Caption1 } from '../Font';
+
+const Nickname = () => {
+  const [nickname, setNickname] = useState('');
+  const [error, setError] = useState(false);
+  const DuplicationCheck = () => {
+    console.log('중복체크');
+    setError(false);
+  };
+  return (
+    <NicknameBox>
+      <ButtonWithInput
+        labelName="닉네임"
+        placeholder="닉네임을 입력해주세요"
+        type="text"
+        btnName="중복"
+        onClick={() => {
+          DuplicationCheck();
+        }}
+        onChange={setNickname}
+        error={error ? '이미 사용중인 닉네임입니다.' : undefined}
+        disabled={nickname.length == 0}
+        notice="영문/숫자 조합 1~20자"
+      />
+      {!error && (
+        <Notice>
+          <Caption1>사용 가능한 닉네임입니다.</Caption1>
+        </Notice>
+      )}
+    </NicknameBox>
+  );
+};
+
+export default Nickname;
+
+const NicknameBox = styled('div', {
+  marginTop: '40px',
+});
+const Notice = styled('div', {
+  color: '$Brand',
+  marginTop: '10px',
+});

--- a/iTER/src/component/signup/Nickname.tsx
+++ b/iTER/src/component/signup/Nickname.tsx
@@ -3,13 +3,14 @@ import { useState } from 'react';
 import ButtonWithInput from '../common/Input';
 import { Caption1 } from '../Font';
 
-const Nickname = () => {
+const Nickname = ({ onDisabled }: { onDisabled: (value: boolean) => void }) => {
   const [nickname, setNickname] = useState('');
   const [error, setError] = useState(false);
   const DuplicationCheck = () => {
     console.log('중복체크');
     setError(false);
   };
+  onDisabled(nickname === '');
   return (
     <NicknameBox>
       <ButtonWithInput

--- a/iTER/src/constants/Category.ts
+++ b/iTER/src/constants/Category.ts
@@ -1,0 +1,61 @@
+export interface CategoryProps {
+  id: number;
+  name: string;
+}
+
+export const CategoryList: CategoryProps[] = [
+  {
+    id: 0,
+    name: '스마트폰',
+  },
+  {
+    id: 1,
+    name: '노트북',
+  },
+  {
+    id: 2,
+    name: 'PC',
+  },
+  {
+    id: 3,
+    name: '스마트워치',
+  },
+  {
+    id: 4,
+    name: '태블릿',
+  },
+  {
+    id: 5,
+    name: '마우스',
+  },
+  {
+    id: 6,
+    name: '키보드',
+  },
+  {
+    id: 7,
+    name: '헤드폰',
+  },
+  {
+    id: 8,
+    name: '스피커',
+  },
+  {
+    id: 9,
+    name: '충전기',
+  },
+  {
+    id: 10,
+    name: '보조배터리',
+  },
+  {
+    id: 11,
+    name: '악세사리',
+  },
+  {
+    id: 12,
+    name: '기타',
+  },
+];
+
+export default CategoryList;

--- a/iTER/src/index.css
+++ b/iTER/src/index.css
@@ -1,6 +1,7 @@
 :root {
   color: '#0A0A0A';
   background-color: #ffffff;
+  font-family: 'Pretendard';
 }
 
 body {

--- a/iTER/src/pages/signup/SignUp.tsx
+++ b/iTER/src/pages/signup/SignUp.tsx
@@ -124,5 +124,5 @@ const Terms = styled('div', {
 const Bottom = styled('div', {
   borderBottom: 'solid 1px #EAEEF2',
   position: 'absolute',
-  bottom: '10px',
+  bottom: '20px',
 });

--- a/iTER/src/pages/signup/SignupAdditional.tsx
+++ b/iTER/src/pages/signup/SignupAdditional.tsx
@@ -14,6 +14,11 @@ const SignupAdditional = () => {
     '관심있는 IT제품을 알려주세요',
   ];
   const [count, setCount] = useState<number>(1);
+  const [disabled, setDisabled] = useState<boolean>(true);
+
+  const onDisabled = (value: boolean) => {
+    setDisabled(value);
+  };
 
   const handleNext = () => {
     if (count < 3) {
@@ -50,9 +55,16 @@ const SignupAdditional = () => {
             </>
           )}
         </Title>
-        {count == 1 ? <Nickname /> : count == 2 ? <Job /> : <Category />}
+        {count == 1 ? (
+          <Nickname onDisabled={onDisabled} />
+        ) : count == 2 ? (
+          <Job onDisabled={onDisabled} />
+        ) : (
+          <Category onDisabled={onDisabled} />
+        )}
         <Bottom>
           <Button
+            disabled={disabled}
             onClick={() => {
               handleNext();
             }}

--- a/iTER/src/pages/signup/SignupAdditional.tsx
+++ b/iTER/src/pages/signup/SignupAdditional.tsx
@@ -8,7 +8,11 @@ import Job from '../../component/signup/Job';
 import Category from '../../component/signup/Category';
 
 const SignupAdditional = () => {
-  const title = ['iTER에서 사용할\n닉네임을 정해주세요', '직업을 알려주세요', '직업을 알려주세요'];
+  const title = [
+    'iTER에서 사용할\n닉네임을 정해주세요',
+    '직업을 알려주세요',
+    '관심있는 IT제품을 알려주세요',
+  ];
   const [count, setCount] = useState<number>(1);
 
   const handleNext = () => {
@@ -37,6 +41,14 @@ const SignupAdditional = () => {
         </Count>
         <Title>
           <Headline3>{title[count - 1]}</Headline3>
+          {count == 3 && (
+            <>
+              <div style={{ height: 4 }} />
+              <Three>
+                <Headline4>(최대 3개까지)</Headline4>
+              </Three>
+            </>
+          )}
         </Title>
         {count == 1 ? <Nickname /> : count == 2 ? <Job /> : <Category />}
         <Bottom>
@@ -58,7 +70,6 @@ const Content = styled('div', {
   height: '100vh',
   overflow: 'hidden',
   paddingLeft: '25px',
-  border: '1px solid red',
 });
 
 const Count = styled('div', {
@@ -72,7 +83,11 @@ const Title = styled('div', {
   height: '56px',
 });
 
+const Three = styled('span', {
+  color: '$Brand',
+});
+
 const Bottom = styled('div', {
   position: 'absolute',
-  bottom: '10px',
+  bottom: '20px',
 });

--- a/iTER/src/pages/signup/SignupAdditional.tsx
+++ b/iTER/src/pages/signup/SignupAdditional.tsx
@@ -1,0 +1,78 @@
+import Top from '../../component/layout/Top';
+import { styled } from '@stitches/react';
+import { useState } from 'react';
+import Button from '../../component/common/Button';
+import { Headline3, Headline4 } from '../../component/Font';
+import Nickname from '../../component/signup/Nickname';
+import Job from '../../component/signup/Job';
+import Category from '../../component/signup/Category';
+
+const SignupAdditional = () => {
+  const title = ['iTER에서 사용할\n닉네임을 정해주세요', '직업을 알려주세요', '직업을 알려주세요'];
+  const [count, setCount] = useState<number>(1);
+
+  const handleNext = () => {
+    if (count < 3) {
+      setCount(count + 1);
+    } else {
+      console.log('회원가입 완료');
+    }
+  };
+
+  return (
+    <>
+      <Top
+        title="회원가입"
+        back={
+          count > 1
+            ? () => {
+                setCount(count - 1);
+              }
+            : undefined
+        }
+      />
+      <Content>
+        <Count>
+          <Headline4>{count}/3</Headline4>
+        </Count>
+        <Title>
+          <Headline3>{title[count - 1]}</Headline3>
+        </Title>
+        {count == 1 ? <Nickname /> : count == 2 ? <Job /> : <Category />}
+        <Bottom>
+          <Button
+            onClick={() => {
+              handleNext();
+            }}
+          >
+            다음
+          </Button>
+        </Bottom>
+      </Content>
+    </>
+  );
+};
+export default SignupAdditional;
+
+const Content = styled('div', {
+  height: '100vh',
+  overflow: 'hidden',
+  paddingLeft: '25px',
+  border: '1px solid red',
+});
+
+const Count = styled('div', {
+  marginTop: '100px',
+  color: '$Gray50',
+});
+
+const Title = styled('div', {
+  marginTop: '17px',
+  marginBottom: '40px',
+  height: '56px',
+});
+
+const Bottom = styled('div', {
+  position: 'absolute',
+  bottom: '10px',
+});

--- a/iTER/src/pages/signup/SignupComplete.tsx
+++ b/iTER/src/pages/signup/SignupComplete.tsx
@@ -1,0 +1,65 @@
+import { Headline2, Headline3 } from '../../component/Font';
+import { styled } from '@stitches/react';
+import Button from '../../component/common/Button';
+import { useNavigate } from 'react-router-dom';
+
+const SignupComplete = () => {
+  const nickname = 'test';
+  const interest = ['tag1', 'tag2', 'tag3'];
+
+  const navigate = useNavigate();
+  return (
+    <Container>
+      <div style={{ margin: '0 auto' }}>
+        <Title>
+          <Headline2>{nickname}님,</Headline2>
+          <Headline2>회원가입을 축하합니다!</Headline2>
+        </Title>
+
+        <Headline3>나의 관심분야는</Headline3>
+        <Hash>
+          <Headline3>
+            #{interest[0]} #{interest[1]} #{interest[2]}
+          </Headline3>
+        </Hash>
+
+        <Bottom>
+          <Button
+            onClick={() => {
+              navigate('/');
+            }}
+          >
+            홈으로 가기
+          </Button>
+        </Bottom>
+      </div>
+    </Container>
+  );
+};
+export default SignupComplete;
+
+const Container = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100vh',
+  position: 'relative',
+  padding: '0 30px',
+  overflow: 'hidden',
+});
+
+const Title = styled('div', {
+  margin: '142px 0 30px 0',
+  textAlign: 'left',
+  width: '360px',
+});
+
+const Hash = styled('div', {
+  margin: '3px 0 0 0',
+  color: '$Brand',
+});
+
+const Bottom = styled('div', {
+  position: 'absolute',
+  bottom: '10px',
+  left: '25px',
+});


### PR DESCRIPTION
##  개요
- feat#25
- 회원가입 이후 화면 구현
<br/>

## 작업 내용
- 회원가입 완료화면
- 회원가입 추가정보 입력화면
- input 컴포넌트 수정
- top 컴포넌트 수정
<br/>

## To Reviewers
구현하다가 input이 약간 px이 달라진거같아서 수정했습니다!

관심 IT제품은 아직 확정이 아닌 것 같아 이미지는 넣지 않았습니다.
선택한 아이템은 그림자 색을 변하게 해뒀습니다.

회원가입 완료화면에 아직 실제 데이터가 들어가지 않습니다!
API 연동하면서 부족한 유효성 검사와 데이터 수정할 것 같습니다.

폰트가 적용이 안되어있더라고요.... 추가했습니다.

Top컴포넌트의 뒤로가기 버튼에 기능 추가했습니다.
원래 뒤로가기만 가능 -> back에 함수 넣어서 전달하면 해당함수 실행

<br/>

## 구현 화면
<img width="403" alt="스크린샷 2023-10-06 오후 2 07 23" src="https://github.com/BETTER-iTER/Web/assets/78204289/69f179d0-5bdc-43d6-936a-253b0f834ea3">

<img width="403" alt="스크린샷 2023-10-06 오후 2 07 07" src="https://github.com/BETTER-iTER/Web/assets/78204289/867bc167-140a-4368-a8fc-15f567daf68c">

<img width="404" alt="스크린샷 2023-10-06 오후 2 06 52" src="https://github.com/BETTER-iTER/Web/assets/78204289/d0c7ea44-69c5-49b7-b890-1fca83030ee1">

<img width="404" alt="스크린샷 2023-10-06 오후 2 06 44" src="https://github.com/BETTER-iTER/Web/assets/78204289/872ff7ec-b2db-430d-90fb-9cfba3cb6211">

