### PR TITLE
Feat#72 마이페이지 팔로워팔로잉 화면

### DIFF
--- a/iTER/src/App.tsx
+++ b/iTER/src/App.tsx
@@ -15,6 +15,7 @@ import Onboading from './pages/Onboading';
 import Interest from './pages/mypage/Interest';
 import Like from './pages/mypage/Like';
 import Index from './pages/mypage/Index';
+import Follow from './pages/mypage/Follow';
 
 function App() {
   return (
@@ -35,6 +36,7 @@ function App() {
       <Route path="/mypage" element={<Index />} />
       <Route path="/mypage/interest" element={<Interest />} />
       <Route path="/mypage/like" element={<Like />} />
+      <Route path="/mypage/follow" element={<Follow />} />
     </Routes>
   );
 }

--- a/iTER/src/component/layout/Top.tsx
+++ b/iTER/src/component/layout/Top.tsx
@@ -23,6 +23,7 @@ export default Top;
 const Container = styled('div', {
   width: '350px',
   height: '60px',
+  minHeight: '60px',
   backgroundColor: '$White',
   display: 'flex',
   justifyContent: 'center',

--- a/iTER/src/pages/mypage/Follow.tsx
+++ b/iTER/src/pages/mypage/Follow.tsx
@@ -1,0 +1,125 @@
+import { useState } from 'react';
+import { styled } from '../../../stitches.config';
+import Top from '../../component/layout/Top';
+import UserIcon from '../../assets/icon/User.svg?react';
+import Bottom from '../../component/common/Bottom';
+import Nav from '../../component/layout/Nav';
+const dummyUser = [
+  { id: 0, username: 'asdmkf' },
+  { id: 1, username: 'asdmkf' },
+  { id: 2, username: 'asdmkf' },
+  { id: 3, username: 'asdmkf' },
+];
+const Follow = () => {
+  const [status, setStatus] = useState<number>(0);
+  return (
+    <div>
+      <Top title="마이페이지" />
+      <StatusBox>
+        <Status
+          active={status == 0}
+          onClick={() => {
+            setStatus(0);
+          }}
+        >
+          팔로워(10)
+        </Status>
+        <Status
+          active={status == 1}
+          onClick={() => {
+            setStatus(1);
+          }}
+        >
+          팔로잉(10)
+        </Status>
+      </StatusBox>
+
+      <Content>
+        {/* 데이터가 없을 경우 -> 나중에 조건 변경 */}
+        {/* {true && (
+          <Empty>
+            {status == 0 && <>리뷰를 작성해 팔로워를 늘려 보세요</>}
+            {status == 1 && <>도움된 리뷰의 유저를 팔로우해 보세요</>}
+          </Empty>
+        )} */}
+
+        {/* 데이터 존재할 때 */}
+        {dummyUser.map((user) => (
+          <Item key={user.id} name={user.username} />
+        ))}
+      </Content>
+      <Nav />
+    </div>
+  );
+};
+
+export default Follow;
+
+const Item = ({ name }: { name: string }) => {
+  return (
+    <ItemBox>
+      {/* <Image /> */}
+      <UserIcon width="45px" height="45px" />
+      {name}
+    </ItemBox>
+  );
+};
+
+const StatusBox = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  width: '100%',
+  borderBottom: '1px solid $Bar',
+});
+
+const Status = styled('div', {
+  backgroundColor: '$White',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '195px',
+  bodyText: 1,
+  padding: '20px 0 10px 0',
+  variants: {
+    active: {
+      true: {
+        borderBottom: '3px solid $TitleBlack',
+      },
+      false: {
+        borderBottom: '3px solid $White',
+        color: '#AFB8C1',
+      },
+    },
+  },
+  zIndex: 100,
+});
+
+const Content = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  paddingTop: '9px',
+  bodyText: 1,
+  color: '$TitleBlack',
+});
+
+const Image = styled('div', {
+  width: '45px',
+  height: '45px',
+  borderRadius: '50%',
+  backgroundColor: '$Gray20',
+});
+
+const ItemBox = styled('div', {
+  height: '45px',
+  width: '340px',
+  display: 'flex',
+  alignItems: 'center',
+  marginTop: '16px',
+  gap: '12px',
+});
+
+const Empty = styled('div', {
+  marginTop: '180px',
+});

--- a/iTER/src/pages/mypage/Follow.tsx
+++ b/iTER/src/pages/mypage/Follow.tsx
@@ -4,16 +4,11 @@ import Top from '../../component/layout/Top';
 import UserIcon from '../../assets/icon/User.svg?react';
 import Bottom from '../../component/common/Bottom';
 import Nav from '../../component/layout/Nav';
-const dummyUser = [
-  { id: 0, username: 'asdmkf' },
-  { id: 1, username: 'asdmkf' },
-  { id: 2, username: 'asdmkf' },
-  { id: 3, username: 'asdmkf' },
-];
+
 const Follow = () => {
   const [status, setStatus] = useState<number>(0);
   return (
-    <div>
+    <Container>
       <Top title="마이페이지" />
       <StatusBox>
         <Status
@@ -49,7 +44,7 @@ const Follow = () => {
         ))}
       </Content>
       <Nav />
-    </div>
+    </Container>
   );
 };
 
@@ -64,6 +59,12 @@ const Item = ({ name }: { name: string }) => {
     </ItemBox>
   );
 };
+
+const Container = styled('div', {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100vh',
+});
 
 const StatusBox = styled('div', {
   display: 'flex',
@@ -100,8 +101,13 @@ const Content = styled('div', {
   flexDirection: 'column',
   alignItems: 'center',
   paddingTop: '9px',
+  paddingBottom: '60px',
   bodyText: 1,
   color: '$TitleBlack',
+  overflowY: 'scroll',
+  '&::-webkit-scrollbar': {
+    display: 'none',
+  },
 });
 
 const Image = styled('div', {
@@ -123,3 +129,19 @@ const ItemBox = styled('div', {
 const Empty = styled('div', {
   marginTop: '180px',
 });
+
+const dummyUser = [
+  { id: 0, username: 'asdmkf' },
+  { id: 1, username: 'asdmkf' },
+  { id: 2, username: 'asdmkf' },
+  { id: 3, username: 'asdmkf' },
+  { id: 4, username: 'asdmkf' },
+  { id: 5, username: 'asdmkf' },
+  { id: 6, username: 'asdmkf' },
+  { id: 7, username: 'asdmkf' },
+  { id: 8, username: 'asdmkf' },
+  { id: 9, username: 'asdmkf' },
+  { id: 10, username: 'asdmkf' },
+  { id: 11, username: 'asdmkf' },
+  { id: 12, username: 'asdmkf' },
+];

--- a/iTER/src/pages/mypage/Index.tsx
+++ b/iTER/src/pages/mypage/Index.tsx
@@ -78,7 +78,7 @@ const StatusBox = styled('div', {
   alignItems: 'center',
   justifyContent: 'space-between',
   width: '100%',
-  height: '48px',
+  borderBottom: '1px solid $Bar',
 });
 
 const Status = styled('div', {
@@ -96,6 +96,7 @@ const Status = styled('div', {
       },
       false: {
         borderBottom: '3px solid $White',
+        color: '#AFB8C1',
       },
     },
   },


### PR DESCRIPTION
##  개요
- feat#72
- 마이페이지 팔로워팔로잉 화면구현
<br/>

## 작업 내용
- 빈 화면 구현
- 팔로워 리스트 구현
<br/>

## To Reviewers
아직 데이터 처리는 하지 않았습니다!
단순하게 화면만 구현했습니다

<br/>

## 구현 화면
<img width="401" alt="스크린샷 2023-11-11 오후 11 04 14" src="https://github.com/BETTER-iTER/Web/assets/78204289/ef7de26a-4d17-4218-a9a1-762cc8a92946">
<img width="410" alt="스크린샷 2023-11-11 오후 11 04 43" src="https://github.com/BETTER-iTER/Web/assets/78204289/34cb370a-9380-47df-b36d-434987c0d2af">
